### PR TITLE
Fix fuzzy text rendering issue within modal dialog.

### DIFF
--- a/dist/showModalDialog.css
+++ b/dist/showModalDialog.css
@@ -1,6 +1,10 @@
 .global-modal-dialog-root {
-  background: rgba(0, 0, 0, 0.2);
+  align-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
   bottom: -100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   left:0;
   position: fixed;
   right: 0;
@@ -14,13 +18,12 @@
 
 .global-modal-dialog.popover {
   animation: popover_fadein 250ms;
-  left: 50%;
+  left: 0;
   max-height: 95vh;;
   max-width: 95vw;
   min-width: 450px;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  position: relative;
+  top: 0;
   z-index: 1051;
 }
 

--- a/src/showModalDialog.css
+++ b/src/showModalDialog.css
@@ -1,6 +1,10 @@
 .global-modal-dialog-root {
-  background: rgba(0, 0, 0, 0.2);
+  align-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
   bottom: -100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   left:0;
   position: fixed;
   right: 0;
@@ -14,13 +18,12 @@
 
 .global-modal-dialog.popover {
   animation: popover_fadein 250ms;
-  left: 50%;
+  left: 0;
   max-height: 95vh;;
   max-width: 95vw;
   min-width: 450px;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  position: relative;
+  top: 0;
   z-index: 1051;
 }
 


### PR DESCRIPTION
For now, we use the follow CSS to center the modal dialog:

  position: absolute;
  top: 50%;
  left: 50%;
  transform: translate(-50%, -50%);
}
The problem is that the text rendered within the modal could be blurred
https://stackoverflow.com/questions/31109299/css-transform-translate-50-50-makes-texts-blurry

With this diff, it removes the transform: translate(-50%, -50%); and uses different CSS
rules to center the modal.