### PR TITLE
trap keyboard focus in modal dialog

### DIFF
--- a/src/showModalDialog.js
+++ b/src/showModalDialog.js
@@ -172,13 +172,10 @@ class Modal extends React.PureComponent {
     // Focusable selectors list from https://stackoverflow.com/a/30753870
     const selector = `button:not([disabled]), [href], iframe, input:not([disabled]), select:not([disabled]),
       textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contentEditable=true]`;
+    // Filter out hidden elements
     const focusableElements = Array.from(
       modalRoot.querySelectorAll(selector)
-    ).filter(element => {
-      // hidden elements are not focusable
-      const style = window.getComputedStyle(element);
-      return style.display !== 'none' && style.visibility !== 'hidden';
-    });
+    ).filter(element => !!element.offsetHeight);
     if (!focusableElements.length) {
       return;
     }


### PR DESCRIPTION
### Summary
[Lodestone bug](https://app.asana.com/0/99939445634885/1179937635451555/f)
This makes sure that pressing "Tab" and "Shift+Tab" never focuses on page elements outside of the modal dialog. 

I tried setting `tabIndex` in `resetModalsAccessibility()` but it felt more complicated to set/reset all focusable elements than limit it to the modal 🙃 let me know if you feel strongly against it

### Testing
1. Confirm that tabbing or shift-tabbing with the modal open always stays within the modal
2. Shift focus to the browser toolbar (using Control + F5) and confirm tabbing works as normal
3. Confirm all clicking works as normal