### PR TITLE
[a11y] change 'Read more' control to a button

### DIFF
--- a/dist/DocsEditorContentOverflowControl.css
+++ b/dist/DocsEditorContentOverflowControl.css
@@ -1,8 +1,5 @@
-.docs-editor-content-overflow-control:link,
-.docs-editor-content-overflow-control:visited,
-.docs-editor-content-overflow-control:hover,
-.docs-editor-content-overflow-control:active {
-  text-decoration: none;
+.docs-editor-content-overflow-control {
+  font-weight: normal;
 }
 
 .docs-editor-content-overflow-control > .icon {

--- a/dist/DocsEditorContentOverflowControl.js
+++ b/dist/DocsEditorContentOverflowControl.js
@@ -66,8 +66,14 @@ var DocsEditorContentOverflowControl = function (_React$PureComponent) {
           'aria-expanded': !contentOverflowHidden,
           bsStyle: 'link',
           className: 'docs-editor-content-overflow-control',
-          onClick: this._onClick,
-          onMouseDown: function onMouseDown(e) {
+          onClick: this._onClick
+          /*
+            Handles a design issue where the button remains focused after clicking it,
+            so rectangular keyboard focus still shows. Using a suggestion from
+            https://stackoverflow.com/a/37580028 to show focus for keyboard users
+            while hiding focus for mouse users.
+          */
+          , onMouseDown: function onMouseDown(e) {
             return e.preventDefault();
           }
         },

--- a/dist/DocsEditorContentOverflowControl.js
+++ b/dist/DocsEditorContentOverflowControl.js
@@ -24,6 +24,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _reactBootstrap = require('react-bootstrap');
+
 require('./DocsEditorContentOverflowControl.css');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -43,7 +45,6 @@ var DocsEditorContentOverflowControl = function (_React$PureComponent) {
     }
 
     return _ret = (_temp = (_this = (0, _possibleConstructorReturn3.default)(this, (_ref = DocsEditorContentOverflowControl.__proto__ || (0, _getPrototypeOf2.default)(DocsEditorContentOverflowControl)).call.apply(_ref, [this].concat(args))), _this), _this._onClick = function (e) {
-      e.preventDefault();
       var _this$props = _this.props,
           contentOverflowHidden = _this$props.contentOverflowHidden,
           onToggle = _this$props.onToggle;
@@ -60,14 +61,19 @@ var DocsEditorContentOverflowControl = function (_React$PureComponent) {
       var icon = contentOverflowHidden ? '\xBB' : '\xAB';
       var text = contentOverflowHidden ? 'Read more' : 'Read less';
       return _react2.default.createElement(
-        'a',
+        _reactBootstrap.Button,
         {
+          'aria-expanded': !contentOverflowHidden,
+          bsStyle: 'link',
           className: 'docs-editor-content-overflow-control',
-          href: '#',
-          onClick: this._onClick },
+          onClick: this._onClick,
+          onMouseDown: function onMouseDown(e) {
+            return e.preventDefault();
+          }
+        },
         _react2.default.createElement(
           'span',
-          { className: 'icon' },
+          { 'aria-hidden': 'true', className: 'icon' },
           icon
         ),
         text

--- a/dist/DocsEditorContentOverflowControl.js.flow
+++ b/dist/DocsEditorContentOverflowControl.js.flow
@@ -21,6 +21,12 @@ class DocsEditorContentOverflowControl extends React.PureComponent {
         bsStyle="link"
         className="docs-editor-content-overflow-control"
         onClick={this._onClick}
+        /*
+          Handles a design issue where the button remains focused after clicking it,
+          so rectangular keyboard focus still shows. Using a suggestion from
+          https://stackoverflow.com/a/37580028 to show focus for keyboard users
+          while hiding focus for mouse users.
+        */
         onMouseDown={e => e.preventDefault()}
       >
         <span aria-hidden="true" className="icon">{icon}</span>

--- a/dist/DocsEditorContentOverflowControl.js.flow
+++ b/dist/DocsEditorContentOverflowControl.js.flow
@@ -1,6 +1,8 @@
 // @flow
 
 import React from 'react';
+import {Button} from 'react-bootstrap';
+
 import './DocsEditorContentOverflowControl.css'
 
 class DocsEditorContentOverflowControl extends React.PureComponent {
@@ -14,18 +16,20 @@ class DocsEditorContentOverflowControl extends React.PureComponent {
     const icon = contentOverflowHidden ? '\u00BB' : '\u00AB';
     const text = contentOverflowHidden ? 'Read more' : 'Read less';
     return (
-      <a
+      <Button
+        aria-expanded={!contentOverflowHidden}
+        bsStyle="link"
         className="docs-editor-content-overflow-control"
-        href="#"
-        onClick={this._onClick}>
-        <span className="icon">{icon}</span>
+        onClick={this._onClick}
+        onMouseDown={e => e.preventDefault()}
+      >
+        <span aria-hidden="true" className="icon">{icon}</span>
         {text}
-      </a>
+      </Button>
     );
   }
 
   _onClick = (e: SyntheticEvent): void => {
-    e.preventDefault();
     const {contentOverflowHidden, onToggle} = this.props;
     onToggle(!contentOverflowHidden);
   };

--- a/src/DocsEditorContentOverflowControl.css
+++ b/src/DocsEditorContentOverflowControl.css
@@ -1,8 +1,5 @@
-.docs-editor-content-overflow-control:link,
-.docs-editor-content-overflow-control:visited,
-.docs-editor-content-overflow-control:hover,
-.docs-editor-content-overflow-control:active {
-  text-decoration: none;
+.docs-editor-content-overflow-control {
+  font-weight: normal;
 }
 
 .docs-editor-content-overflow-control > .icon {

--- a/src/DocsEditorContentOverflowControl.js
+++ b/src/DocsEditorContentOverflowControl.js
@@ -21,6 +21,12 @@ class DocsEditorContentOverflowControl extends React.PureComponent {
         bsStyle="link"
         className="docs-editor-content-overflow-control"
         onClick={this._onClick}
+        /*
+          Handles a design issue where the button remains focused after clicking it,
+          so rectangular keyboard focus still shows. Using a suggestion from
+          https://stackoverflow.com/a/37580028 to show focus for keyboard users
+          while hiding focus for mouse users.
+        */
         onMouseDown={e => e.preventDefault()}
       >
         <span aria-hidden="true" className="icon">{icon}</span>

--- a/src/DocsEditorContentOverflowControl.js
+++ b/src/DocsEditorContentOverflowControl.js
@@ -1,6 +1,8 @@
 // @flow
 
 import React from 'react';
+import {Button} from 'react-bootstrap';
+
 import './DocsEditorContentOverflowControl.css'
 
 class DocsEditorContentOverflowControl extends React.PureComponent {
@@ -14,18 +16,20 @@ class DocsEditorContentOverflowControl extends React.PureComponent {
     const icon = contentOverflowHidden ? '\u00BB' : '\u00AB';
     const text = contentOverflowHidden ? 'Read more' : 'Read less';
     return (
-      <a
+      <Button
+        aria-expanded={!contentOverflowHidden}
+        bsStyle="link"
         className="docs-editor-content-overflow-control"
-        href="#"
-        onClick={this._onClick}>
-        <span className="icon">{icon}</span>
+        onClick={this._onClick}
+        onMouseDown={e => e.preventDefault()}
+      >
+        <span aria-hidden="true" className="icon">{icon}</span>
         {text}
-      </a>
+      </Button>
     );
   }
 
   _onClick = (e: SyntheticEvent): void => {
-    e.preventDefault();
     const {contentOverflowHidden, onToggle} = this.props;
     onToggle(!contentOverflowHidden);
   };


### PR DESCRIPTION
[Asana bug](https://app.asana.com/0/1184231738262737/1184231738262843/f)

This fixes a few accessibility problems with the "Read more" link:
- Changes it to a button since it functions like a button
- Adds "aria-expanded" for screen readers to announce state
- Hides arrow icon from screen readers

(Ignore `dist/` files, they're auto-generated from running `build_dist.py`)

### Test Plan
Confirm screen reader announces correct info:
<img width="1352" alt="Screen Shot 2020-08-07 at 10 34 38 AM" src="https://user-images.githubusercontent.com/15840841/89672529-a8189280-d899-11ea-896f-e995a0aaf3ce.png">
<img width="1341" alt="Screen Shot 2020-08-07 at 10 27 21 AM" src="https://user-images.githubusercontent.com/15840841/89672538-ac44b000-d899-11ea-993b-5b2efabbac29.png">

Confirm you can keyboard navigate and the button has visible focus