### PR TITLE
allow retrieving proxy image using blob

### DIFF
--- a/src/DocsEditorRuntime.js
+++ b/src/DocsEditorRuntime.js
@@ -19,6 +19,9 @@ class DocsEditorRuntime {
   canComment(): boolean {
     return false;
   }
+  canProxyImageObjectURL(src: string): boolean {
+    return false;
+  }
   canProxyImageSrc(src: string): boolean {
     return false;
   }
@@ -27,6 +30,9 @@ class DocsEditorRuntime {
   }
   getProxyImageSrc(src: string): string {
     return src;
+  }
+  getProxyImageObjectURL(): ?string {
+    return null;
   }
   uploadImage (obj: Blob): Promise<ImageLike> {
     return Promise.reject('Unsupported');

--- a/src/DocsEditorRuntime.js
+++ b/src/DocsEditorRuntime.js
@@ -19,7 +19,7 @@ class DocsEditorRuntime {
   canComment(): boolean {
     return false;
   }
-  canProxyImageObjectURL(src: string): boolean {
+  canProxyImageBlob(src: string): boolean {
     return false;
   }
   canProxyImageSrc(src: string): boolean {
@@ -28,11 +28,11 @@ class DocsEditorRuntime {
   createCommentThreadID(): string {
     return '';
   }
+  getProxyImageBlob(): ?Blob {
+    return null;
+  }
   getProxyImageSrc(src: string): string {
     return src;
-  }
-  getProxyImageObjectURL(): ?string {
-    return null;
   }
   uploadImage (obj: Blob): Promise<ImageLike> {
     return Promise.reject('Unsupported');

--- a/src/DocsSafeImage.js
+++ b/src/DocsSafeImage.js
@@ -48,6 +48,10 @@ class DocsSafeImage extends React.PureComponent {
   }
 
   componentWillUnmount(): void {
+    const {objectURL} = this.state;
+    if (objectURL) {
+      URL.revokeObjectURL(objectURL);
+    }
     this._unmounted = true;
   }
 
@@ -61,7 +65,7 @@ class DocsSafeImage extends React.PureComponent {
 
     if (objectURL) {
       src = objectURL;
-    } else if (src && runtime && runtime.canProxyImageObjectURL(src)) {
+    } else if (src && runtime && runtime.canProxyImageBlob(src)) {
       this._getProxyImageObjectURL(runtime, src);
       src = null;
     } else if (src && runtime && runtime.canProxyImageSrc(src)) {
@@ -183,7 +187,8 @@ class DocsSafeImage extends React.PureComponent {
 
   _getProxyImageObjectURL = async (runtime, src): Promise<void> => {
     try {
-      const objectURL = await runtime.getProxyImageObjectURL(src);
+      const imageBlob = await runtime.getProxyImageBlob(src);
+      const objectURL = URL.createObjectURL(imageBlob);
       this.setState({objectURL});  
     } catch(ex) {
       this.setState({error: true, pending: false});

--- a/src/DocsSafeImage.js
+++ b/src/DocsSafeImage.js
@@ -41,6 +41,14 @@ class DocsSafeImage extends React.PureComponent {
   _renderedSrc = null;
   _unmounted = false;
 
+  componentDidMount(): void {
+    this._maybeLoadObjectUrl();
+  }
+
+  componentDidUpdate(): void {
+    this._maybeLoadObjectUrl();
+  }
+
   componentWillReceiveProps(nextProps: Props): void {
     if (nextProps.src !== this.props.src) {
       const {objectURL} = this.state;
@@ -71,7 +79,6 @@ class DocsSafeImage extends React.PureComponent {
       if (objectURL) {
         src = objectURL;
       } else if (src && runtime && runtime.canProxyImageBlob(src)) {
-        this._getProxyImageObjectURL(runtime, src);
         src = null;
       } else if (src && runtime && runtime.canProxyImageSrc(src)) {
         src = runtime.getProxyImageSrc(src);
@@ -190,6 +197,16 @@ class DocsSafeImage extends React.PureComponent {
       onError(new Error(msg));
     }
   };
+
+  _maybeLoadObjectUrl(): void {
+    const {src} = this.props;
+    const {objectURL} = this.state;
+    const {runtime} = this.context.docsContext;
+
+    if (!objectURL && src && runtime && runtime.canProxyImageBlob(src)) {
+      this._getProxyImageObjectURL(runtime, src);
+    }
+  }
 
   _getProxyImageObjectURL = async (runtime, src): Promise<void> => {
     try {


### PR DESCRIPTION
This PR adds option in runtime to proxy image by retrieving blob. This is driven by security consideration where the proxy endpoint needs to be called via post call, passing csrf token in header.